### PR TITLE
Potential fix for code scanning alert no. 8: Slice memory allocation with excessive size value

### DIFF
--- a/internal/services/device_admin_service.go
+++ b/internal/services/device_admin_service.go
@@ -44,6 +44,9 @@ func (s *DeviceAdminService) CreateDevices(ctx context.Context, input *models.De
 	if input.Quantity <= 0 {
 		input.Quantity = 1
 	}
+	if input.Quantity > 100 {
+		return nil, errors.New("quantity cannot exceed 100")
+	}
 
 	status := strings.TrimSpace(input.Status)
 	if status == "" {


### PR DESCRIPTION
Potential fix for [https://github.com/SJ-tech-Sweden/warehousecore/security/code-scanning/8](https://github.com/SJ-tech-Sweden/warehousecore/security/code-scanning/8)

In general, the fix is to enforce a sensible maximum on `input.Quantity` at the point where it is used to allocate memory, and to reject negative or excessively large values before any slice allocation or looping. This ensures that, regardless of which caller invokes `CreateDevices`, the service will never allocate unbounded memory based on user input.

The single best fix here is to add validation for `input.Quantity` inside `DeviceAdminService.CreateDevices` in `internal/services/device_admin_service.go`, before the `make([]string, 0, input.Quantity)` call and before the `for i := 0; i < input.Quantity; i++` loop. We can mirror the handler’s existing limit of 100 devices per request to avoid changing intended behavior, while making the service self-contained and safe. Concretely:

- After the existing block that normalizes `input.Quantity` to at least 1 (`if input.Quantity <= 0 { input.Quantity = 1 }`), add a check such as:
  - if `input.Quantity > 100`, return an error (e.g., `errors.New("quantity cannot exceed 100")`).
- This guarantees that `input.Quantity` is now in `[1,100]` before it is used in `make` and in the loop.
- No new imports are needed; `errors` is already imported and used.

No changes are required in `internal/handlers/device_admin_handlers.go` for correctness, though the existing handler-side limit will now be redundant but harmless. The main functional behavior remains the same: attempts to create more than 100 devices will be rejected; the only difference is that this rule is now also enforced in the service for any other callers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
